### PR TITLE
Add cmake-based gtest comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+project(t96 LANGUAGES CXX Fortran)
+
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(t96_cpp SHARED t96.cc)
+target_include_directories(t96_cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Build gtest from sources in /usr/src/googletest
+add_subdirectory(/usr/src/googletest googletest-build EXCLUDE_FROM_ALL)
+
+# Compile Fortran code
+add_library(t96_fortran STATIC T96.f)
+
+# The C++ port library
+add_library(t96_cpp_lib SHARED ../src/t96.cc)
+
+# gtest test
+add_executable(t96_compare testfortran_gtest.cpp)
+
+target_include_directories(t96_compare PRIVATE ../src)
+
+target_link_libraries(t96_compare
+    PRIVATE t96_cpp_lib t96_fortran gtest_main)
+
+add_test(NAME t96_compare_tests COMMAND t96_compare)

--- a/tests/testfortran_gtest.cpp
+++ b/tests/testfortran_gtest.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+extern "C" {
+    void t96_(int *iopt, double *parmod, double *ps,
+              double *x, double *y, double *z,
+              double *bx, double *by, double *bz);
+}
+
+void t96(int iopt, const std::array<double,10>& parmod, double ps,
+         double x, double y, double z,
+         double& bx, double& by, double& bz);
+
+TEST(T96Compare, RandomSamples) {
+    const int numTests = 50;
+    double parmod[10] = {0};
+    for (int i=0;i<numTests;++i) {
+        double x = -20.0 + (rand() / (double)RAND_MAX)*30.0;
+        double y = -10.0 + (rand() / (double)RAND_MAX)*20.0;
+        double z = -10.0 + (rand() / (double)RAND_MAX)*20.0;
+        double psi = (-35.0 + (rand() / (double)RAND_MAX)*70.0) * M_PI/180.0;
+        int iopt = 1 + rand()%7;
+        double bx_f, by_f, bz_f;
+        double bx_c, by_c, bz_c;
+        t96_(&iopt, parmod, &psi, &x, &y, &z, &bx_f, &by_f, &bz_f);
+        std::array<double,10> p = {};
+        t96(iopt, p, psi, x, y, z, bx_c, by_c, bz_c);
+        EXPECT_NEAR(bx_f, bx_c, 1e-5);
+        EXPECT_NEAR(by_f, by_c, 1e-5);
+        EXPECT_NEAR(bz_f, bz_c, 1e-5);
+    }
+}
+
+int main(int argc,char** argv){
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add root CMakeLists and subdirectories
- add src and tests build rules
- new gtest comparing C++ t96 against Fortran implementation

## Testing
- `cmake ..`
- `make -j2` *(fails: missing symbols in `t96.cc`)*